### PR TITLE
Add age gate ZK circuit (zkArb SDK)

### DIFF
--- a/zk-integration/circuits/ageGate.circom
+++ b/zk-integration/circuits/ageGate.circom
@@ -1,0 +1,23 @@
+pragma circom 2.0.0;
+
+// Age Gate circuit for the REKT zkArb SDK integration.
+// Proves a user is 18 or older WITHOUT revealing their real age.
+//
+// Private input : age      (kept secret)
+// Public output : isAdult  (1 if age >= 18, otherwise 0)
+
+include "comparators.circom";
+
+template AgeGate() {
+    signal input age;        // private: the user's real age (never revealed)
+    signal output isAdult;   // public: 1 if 18 or older, else 0
+
+    // GreaterEqThan(8) compares numbers up to 255 (plenty for an age).
+    component check = GreaterEqThan(8);
+    check.in[0] <== age;     // the user's age
+    check.in[1] <== 18;      // the minimum age
+
+    isAdult <== check.out;   // result becomes the public output
+}
+
+component main = AgeGate();


### PR DESCRIPTION
Adds a small Circom circuit (ageGate.circom) for the zkArb SDK integration. It proves a user is 18+ without revealing their exact age — useful for token sale / launch compliance.